### PR TITLE
Add playlist.load action

### DIFF
--- a/docs/message-format.md
+++ b/docs/message-format.md
@@ -200,6 +200,23 @@ Set using an offset of the current volume:
 
 `clear`: clear the existing playlist
 
+## Load
+
+Appends the content of the given playlist to the player's current playlist
+
+### command.radio.`<id>`
+
+    {
+      action: 'playlist.load',
+      playlist: [
+        '<file-path>',
+        '<url>'
+      ],
+      clear: <true|false>
+    }
+
+`clear`: clear the existing playlist before loading
+
 ## Clear
 
 ### command.radio.`<id>`

--- a/lib/action.js
+++ b/lib/action.js
@@ -19,6 +19,7 @@ var actions = {
   'playlist.add'    : require('./actions/playlist/add'),
   'playlist.clear'  : SimpleCommand('clear'),
   'playlist.delete' : ToggleCommand('delete'),
+  'playlist.load'    : require('./actions/playlist/load'),
   'playlist.move'   : require('./actions/playlist/move'),
 };
 

--- a/lib/actions/playlist/load.js
+++ b/lib/actions/playlist/load.js
@@ -1,0 +1,15 @@
+var utils = require('radiodan-client').utils;
+
+module.exports = function(radio, options) {
+  var mpdCommands = [];
+
+  if (options.clear) {
+    mpdCommands.push(['clear']);
+  }
+
+  options.playlist.forEach(function(file) {
+    mpdCommands.push(['load', file]);
+  });
+
+  return radio.sendCommands(mpdCommands);
+};

--- a/lib/validators/action.js
+++ b/lib/validators/action.js
@@ -21,6 +21,7 @@ var validators = {
   'player.volume'   : require('./actions/player/volume'),
   'player.status'   : empty,
   'playlist.add'    : require('./actions/playlist/add'),
+  'playlist.load'   : require('./actions/playlist/add'), // same as add
   'playlist.clear'  : empty,
   'playlist.delete' : position,
   'playlist.move'   : require('./actions/playlist/move'),

--- a/test/actions/playlist/test-load.js
+++ b/test/actions/playlist/test-load.js
@@ -1,0 +1,28 @@
+var subject = require(libDir + 'actions/playlist/load');
+
+describe('playlist.load action', function() {
+  it('load given tracks to current playlist', function() {
+    var radio = { sendCommands: sinon.spy() };
+
+    subject(radio, {playlist: ['track.m3u']});
+    assert.equal(1, radio.sendCommands.callCount);
+    assert.deepEqual(
+      [['load', 'track.m3u']],
+      radio.sendCommands.firstCall.args[0]
+    );
+  });
+
+  it('clears current playlist if clear flag is set', function() {
+    var radio = { sendCommands: sinon.spy() };
+
+    subject(radio, {
+      playlist: ['track0.m3u', 'track1.m3u'],
+      clear: true
+    });
+
+    assert.equal(1, radio.sendCommands.callCount);
+    assert.deepEqual([
+      ['clear'], ['load', 'track0.m3u'], ['load', 'track1.m3u']
+    ], radio.sendCommands.firstCall.args[0]);
+  });
+});


### PR DESCRIPTION
Allow radiodan to load another playlist contents into it's own active playlist. It uses the same parameters as `playlist.add`.
