### PR TITLE
Fix play and seek actions

### DIFF
--- a/lib/actions/player/play.js
+++ b/lib/actions/player/play.js
@@ -3,7 +3,7 @@ var utils = require('radiodan-client').utils;
 module.exports = function(radio, options) {
   var mpdCommands = ['play'];
 
-  if (options.position) {
+  if (options.hasOwnProperty('position')) {
     mpdCommands.push(options.position);
   }
 

--- a/lib/actions/player/seek.js
+++ b/lib/actions/player/seek.js
@@ -3,7 +3,7 @@ var utils = require('radiodan-client').utils;
 module.exports = function(radio, options) {
   var mpdCommands = [];
 
-  if(options.position) {
+  if (options.hasOwnProperty('position')) {
     mpdCommands = ['seek', options.position, options.time];
   } else {
     mpdCommands = ['seekcur', options.time];

--- a/test/actions/player/test-play.js
+++ b/test/actions/player/test-play.js
@@ -20,5 +20,14 @@ describe('player.play action', function() {
         ['play', 10]
     ]));
   });
-});
 
+  it('sends the play command with position 0', function() {
+    var radio = { sendCommands: sinon.spy() };
+
+    subject(radio, {position: 0});
+
+    assert.ok(radio.sendCommands.calledWith([
+        ['play', 0]
+    ]));
+  });
+});

--- a/test/actions/player/test-seek.js
+++ b/test/actions/player/test-seek.js
@@ -20,5 +20,14 @@ describe('player.seek action', function() {
       ['seek', 2, 33]
     ]));
   });
-});
 
+  it('sends the seek command with playlist position 0 and seek time', function() {
+    var radio = { sendCommands: sinon.spy() };
+
+    subject(radio, {position: 0, time: 33});
+
+    assert.ok(radio.sendCommands.calledWith([
+      ['seek', 0, 33]
+    ]));
+  });
+});


### PR DESCRIPTION
I found that the `playlist.play` and `playlist.seek` commands weren't working with the `position` parameter set to zero. This pull request includes fixes for these actions, with test cases.

Chris