### PR TITLE
Add jshint and 'use strict'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -22,15 +23,42 @@ module.exports = function(grunt) {
         },
         files: ['test/**/test-*.js', 'lib/**/*.js'],
         tasks: ['default']
-     }
-   }
+      }
+    },
+    jshint: {
+      src: {
+        src: ['Gruntfile.js', 'lib/**/*.js', 'bin/*'],
+        options: {
+          node: true
+        }
+      },
+      test: {
+        src: ['test/**/*.js'],
+        options: {
+          node: true,
+          globals: {
+            it: true,
+            describe: true,
+            assert: true,
+            libDir: true,
+            sinon: true,
+            before: true,
+            beforeEach: true,
+            utils: true,
+            EventEmitter: true,
+            fs: true,
+            winston: true
+          }
+        }
+      }
+    }
   });
 
   // On watch events, if the changed file is a test file then configure mochaTest to only
   // run the tests from that file. Otherwise run all the tests
   var defaultTestSrc = grunt.config('mochaTest.test.src');
   grunt.event.on('watch', function(action, filepath) {
-  console.log(filepath);
+    console.log(filepath);
     grunt.config('mochaTest.test.src', defaultTestSrc);
     if (filepath.match('test/')) {
       grunt.config('mochaTest.test.src', filepath);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,5 +65,5 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('default', ['mochaTest']);
+  grunt.registerTask('default', ['jshint', 'mochaTest']);
 };

--- a/bin/bbc-streams
+++ b/bin/bbc-streams
@@ -7,14 +7,14 @@ var url     = 'http://bbcservices.herokuapp.com/services.json',
     target = process.argv[2] || 'r4',
     request = http.normalizeRequest(url);
 
-request.headers['Authorization'] = 'Basic ' + new Buffer('radiodan:radiodan').toString('base64');
+request.headers.Authorization = 'Basic ' + new Buffer('radiodan:radiodan').toString('base64');
 
 http.request(request).then(function (response) {
   return response.body.read();
 }).then(function (body) {
   return Q.resolve( JSON.parse(body.toString()).services );
 }).then(function (services) {
-  var found = services.filter(function (service) { return service.stream_id == target });
+  var found = services.filter(function (service) { return service.stream_id == target; });
   return Q.resolve(found[0]);
 }).then(function (service){
   console.log(service.streams[0].url);

--- a/bin/bbc-streams
+++ b/bin/bbc-streams
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict';
+
 var Q    = require('q'),
     http = require('q-io/http');
 

--- a/bin/cli
+++ b/bin/cli
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+'use strict';
+
 var program  = require('optimist'),
     sendCommand = require('../lib/cli/send-command'),
     interactivePrompt = require('../lib/cli/interactive-prompt'),
@@ -10,7 +13,8 @@ var queueHost,
     argv,
     messaging,
     radio,
-    interactive;
+    interactive,
+    promise;
 
 /*
   Command-line options

--- a/bin/monitor
+++ b/bin/monitor
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+'use strict';
+
 var RadiodanClient  = require('radiodan-client'),
     MessagingClient = RadiodanClient.MessagingClient,
     utils = RadiodanClient.utils;

--- a/bin/monitor
+++ b/bin/monitor
@@ -3,7 +3,7 @@ var RadiodanClient  = require('radiodan-client'),
     MessagingClient = RadiodanClient.MessagingClient,
     utils = RadiodanClient.utils;
 
-var client = MessagingClient.create()
+var client = MessagingClient.create();
 
 client.createAndBindToExchange({
   queueName: 'testqueue',

--- a/bin/server
+++ b/bin/server
@@ -15,13 +15,10 @@ program
   .option('--log-level [level]', 'Set the log level to [level]', 'info')
   .parse(process.argv);
 
-switch (true) {
-  case program.args.length == 1:
-    configFile = path.resolve(__dirname+'/..', program.args[0]);
-    break;
-  case program.args.length > 1:
-  default:
-    program.help();
+if (program.args.length === 1) {
+  configFile = path.resolve(__dirname+'/..', program.args[0]);
+} else {
+  program.help();
 }
 
 // Set log level

--- a/bin/server
+++ b/bin/server
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
 
+'use strict';
+
 var program      = require('commander'),
     path         = require('path'),
     utils        = require('radiodan-client').utils,
     bootstrap    = require('../lib/bootstrap'),
     audioDevice  = require('../lib/system/audio'),
-    package      = require('../package.json'),
+    pkg          = require('../package.json'),
     configFile,
     config;
 
 program
-  .version(package.version)
+  .version(pkg.version)
   .usage('[options] config_file')
   .option('--log-level [level]', 'Set the log level to [level]', 'info')
   .parse(process.argv);

--- a/lib/action.js
+++ b/lib/action.js
@@ -1,25 +1,27 @@
+'use strict';
+
 var Invoker       = require('./invoker'),
     validator     = require('./validators/action'),
-    SimpleCommand = require('./actions/simple-command'),
-    ToggleCommand = require('./actions/toggle-command');
+    simpleCommand = require('./actions/simple-command'),
+    toggleCommand = require('./actions/toggle-command');
 
 var actions = {
   'database.search' : require('./actions/database/search'),
   'database.update' : require('./actions/database/update'),
-  'player.next'     : SimpleCommand('next'),
-  'player.pause'    : ToggleCommand('pause'),
+  'player.next'     : simpleCommand('next'),
+  'player.pause'    : toggleCommand('pause'),
   'player.play'     : require('./actions/player/play'),
-  'player.previous' : SimpleCommand('previous'),
-  'player.random'   : ToggleCommand('random'),
-  'player.repeat'   : ToggleCommand('repeat'),
+  'player.previous' : simpleCommand('previous'),
+  'player.random'   : toggleCommand('random'),
+  'player.repeat'   : toggleCommand('repeat'),
   'player.seek'     : require('./actions/player/seek'),
-  'player.stop'     : SimpleCommand('stop'),
+  'player.stop'     : simpleCommand('stop'),
   'player.volume'   : require('./actions/player/volume'),
   'player.status'   : require('./actions/player/status'),
   'playlist.add'    : require('./actions/playlist/add'),
-  'playlist.clear'  : SimpleCommand('clear'),
-  'playlist.delete' : ToggleCommand('delete'),
-  'playlist.load'    : require('./actions/playlist/load'),
+  'playlist.clear'  : simpleCommand('clear'),
+  'playlist.delete' : toggleCommand('delete'),
+  'playlist.load'   : require('./actions/playlist/load'),
   'playlist.move'   : require('./actions/playlist/move'),
 };
 

--- a/lib/actions/database/search.js
+++ b/lib/actions/database/search.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils          = require('radiodan-client').utils,
     formatResponse = require('../../states/playlist').formatResponse;
 

--- a/lib/actions/database/update.js
+++ b/lib/actions/database/update.js
@@ -1,8 +1,9 @@
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {
-  var options = options || {},
-      command;
+  var command;
+
+  options = options || {};
 
   if (options.force) {
     command = 'rescan';

--- a/lib/actions/database/update.js
+++ b/lib/actions/database/update.js
@@ -1,7 +1,9 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {
-  var command;
+  var command, mpdCommands;
 
   options = options || {};
 

--- a/lib/actions/player/play.js
+++ b/lib/actions/player/play.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/actions/player/random.js
+++ b/lib/actions/player/random.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/actions/player/repeat.js
+++ b/lib/actions/player/repeat.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/actions/player/seek.js
+++ b/lib/actions/player/seek.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/actions/player/status.js
+++ b/lib/actions/player/status.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils       = require('radiodan-client').utils,
     playerState = require('../../state');
 

--- a/lib/actions/player/volume.js
+++ b/lib/actions/player/volume.js
@@ -1,8 +1,12 @@
+'use strict';
+
 var utils = require('radiodan-client').utils,
     state = require('../../state'),
     boundVolume = require('../../utils/bound-volume');
 
 module.exports = function(radio, opts) {
+  var logger;
+
   opts   = opts        || {};
   logger = opts.logger || utils.logger(__filename);
   state  = opts.state  || state;

--- a/lib/actions/playlist/add.js
+++ b/lib/actions/playlist/add.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/actions/playlist/load.js
+++ b/lib/actions/playlist/load.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/actions/playlist/move.js
+++ b/lib/actions/playlist/move.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/actions/simple-command.js
+++ b/lib/actions/simple-command.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = function simpleCommand(command) {
   return function (radio) {

--- a/lib/actions/simple-command.js
+++ b/lib/actions/simple-command.js
@@ -2,5 +2,5 @@
 module.exports = function simpleCommand(command) {
   return function (radio) {
     return radio.sendCommands([[command]]);
-  }
-}
+  };
+};

--- a/lib/actions/toggle-command.js
+++ b/lib/actions/toggle-command.js
@@ -3,5 +3,5 @@ var utils = require('radiodan-client').utils;
 module.exports = function (command) {
   return function(radio, options) {
     return radio.sendCommands([ [command, options.value] ]);
-  }
+  };
 };

--- a/lib/actions/toggle-command.js
+++ b/lib/actions/toggle-command.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function (command) {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,5 +1,5 @@
 var utils             = require('radiodan-client').utils,
-    radioPlayer       = require('./radio-player')
+    radioPlayer       = require('./radio-player'),
     configParser      = require('./bootstrap/config'),
     addSystemDefaults = require('./bootstrap/add-system-defaults'),
     createPaths       = require('./bootstrap/create-paths'),

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils             = require('radiodan-client').utils,
     radioPlayer       = require('./radio-player'),
     configParser      = require('./bootstrap/config'),

--- a/lib/bootstrap/add-system-defaults.js
+++ b/lib/bootstrap/add-system-defaults.js
@@ -22,6 +22,8 @@ function create(defaultPath, platform) {
   return { add: addDefaults };
 
   function addDefaults(config) {
+    var newConfig;
+
     config = config || {};
 
     var radioPath = path.join(rootPath, config.id.toString()),
@@ -32,9 +34,9 @@ function create(defaultPath, platform) {
           db:       path.join(radioPath, "mpd.db"),
         }, platformDefaults);
 
-    var configDefaults = mergeObjects(systemDefaults, configDefaults),
-        newConfig      = mergeObjects(configDefaults, config);
+    configDefaults = mergeObjects(systemDefaults, configDefaults);
+    newConfig      = mergeObjects(configDefaults, config);
 
     return newConfig;
-  };
+  }
 }

--- a/lib/bootstrap/add-system-defaults.js
+++ b/lib/bootstrap/add-system-defaults.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var os    = require('os'),
     path  = require('path'),
     utils = require('radiodan-client').utils,

--- a/lib/bootstrap/config.js
+++ b/lib/bootstrap/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function (config, idGenerator) {

--- a/lib/bootstrap/create-paths.js
+++ b/lib/bootstrap/create-paths.js
@@ -25,7 +25,7 @@ module.exports = function (config, configPath, newPath, newMkdir) {
       config[pathKey] = resolvedPath;
     }
   });
-}
+};
 
 function resolvePath(relativePath, configPath) {
   var fullPath, configDir;

--- a/lib/bootstrap/create-paths.js
+++ b/lib/bootstrap/create-paths.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var mkdirp   = require('mkdirp'),
     path     = require('path'),
     utils    = require('radiodan-client').utils,

--- a/lib/child-process.js
+++ b/lib/child-process.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils,
     childProcess = require('child_process'),
     defaultLogger = utils.logger(__filename);

--- a/lib/child-process.js
+++ b/lib/child-process.js
@@ -9,10 +9,10 @@ module.exports = {
 function create(execCommand, params) {
   return processPath(execCommand)
     .then(
-      function(path) { return spawnProcess(path, params) }
+      function(path) { return spawnProcess(path, params); }
     )
     .then(null, utils.failedPromiseHandler(defaultLogger));
-};
+}
 
 function processPath(cmd, exec) {
   exec = exec || utils.promise.denodeify(childProcess.exec);

--- a/lib/cli/interactive-prompt.js
+++ b/lib/cli/interactive-prompt.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var readline = require('readline'),
     EventEmitter = require('events').EventEmitter,
     sendCommand = require('./send-command');
@@ -42,7 +44,7 @@ function interactiveCommandPrompt(program, radio) {
   and execute commands found
 */
 function processInputLine(cmd, program, radio) {
-  var command;
+  var command, options;
 
   if (cmd === 'exit') {
     console.log('Goodbye.\n');

--- a/lib/cli/send-command.js
+++ b/lib/cli/send-command.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 /*

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils,
     logger = utils.logger(__filename);
 

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -6,9 +6,10 @@ function defaultInvokeActionWithRadio(radio, method, options) {
 }
 
 function create(methods, validator, invokeAction) {
-  var methods = methods || {},
-      instance = {},
-      invokeAction = invokeAction || defaultInvokeActionWithRadio;
+  var instance = {};
+
+  methods = methods || {};
+  invokeAction = invokeAction || defaultInvokeActionWithRadio;
 
   instance.methods = methods;
   instance.invoke = function (radio, methodName, options) {
@@ -35,7 +36,7 @@ function create(methods, validator, invokeAction) {
     } else {
       return runInvokeAction(options);
     }
-  }
+  };
 
   return instance;
 }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var configFile    = require(__dirname + '/player/config'),
     portFinder    = require(__dirname + '/port-finder').create(),
     mpdClient     = require(__dirname + '/player/mpd/client'),

--- a/lib/player/config.js
+++ b/lib/player/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Mustache   = require('mustache'),
     fs         = require('fs'),
     tmp        = require('tmp'),

--- a/lib/player/config.js
+++ b/lib/player/config.js
@@ -26,8 +26,8 @@ module.exports.create = function(options, portsPromise) {
         });
       })
       .then(null, utils.failedPromiseHandler(logger));
-  };
-}
+  }
+};
 
 function renderTemplate(options, ports) {
   var templateFile = templatePath.replace('%s', options.player),
@@ -44,6 +44,6 @@ function writeConfigToDisk(content) {
 
   return generateFileName.then(function(tmpFilePath) {
     return utils.promise.nfcall(fs.writeFile, tmpFilePath, content)
-      .then(function() { return tmpFilePath });
+      .then(function() { return tmpFilePath; });
   });
 }

--- a/lib/player/mpd/client.js
+++ b/lib/player/mpd/client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var mpd     = require('mpd'),
     EventEmitter = require('events').EventEmitter,
     utils = require('radiodan-client').utils;

--- a/lib/player/mpd/client.js
+++ b/lib/player/mpd/client.js
@@ -77,7 +77,7 @@ exports.create = function (config, logger) {
 
     var commandList = commands.map(formatCommand),
         promise     = instance.ready().then(function() {
-          return utils.promise.ninvoke(client, 'sendCommands', commandList)
+          return utils.promise.ninvoke(client, 'sendCommands', commandList);
         }).then(null, utils.failedPromiseHandler(logger));
 
     return promise;
@@ -91,7 +91,7 @@ exports.create = function (config, logger) {
   instance.connect        = connect;
   instance.id             = id;
   instance.config         = config;
-  instance.ready          = function() { return ready.promise } ;
+  instance.ready          = function() { return ready.promise; };
 
   return instance;
 };

--- a/lib/player/player-process.js
+++ b/lib/player/player-process.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils        = require('radiodan-client').utils,
     defaultChildProcess = require(__dirname + '/../child-process'),
     playerProcesses = {

--- a/lib/player/player-process.js
+++ b/lib/player/player-process.js
@@ -6,10 +6,12 @@ var utils        = require('radiodan-client').utils,
     };
 
 module.exports.create = function(playerType, configFile, childProcess) {
+  var params;
+
   childProcess = childProcess || defaultChildProcess;
 
   if(playerProcesses.hasOwnProperty(playerType)) {
-    var params = playerProcesses[playerType](configFile);
+    params = playerProcesses[playerType](configFile);
   } else {
     return utils.promise.reject(
         'Unknown player type ' + playerType

--- a/lib/port-finder.js
+++ b/lib/port-finder.js
@@ -6,7 +6,7 @@ portfinder.basePort = 49152;
 
 portfinder.nextPortPromise = function() {
   return utils.promise.nfcall(portfinder.getPort);
-}
+};
 
 module.exports.create = function(portGenerator){
   var instance = {};

--- a/lib/port-finder.js
+++ b/lib/port-finder.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var portfinder = require('portfinder'),
     utils      = require('radiodan-client').utils;
 
@@ -15,7 +17,8 @@ module.exports.create = function(portGenerator){
 
   instance.next = function(numPorts) {
     var portPromises = [],
-        portCount = parseInt(numPorts, 10);
+        portCount = parseInt(numPorts, 10),
+        i;
 
     for(i=0; i<portCount; i++) {
       var p = portGenerator.nextPortPromise();

--- a/lib/radio-controller.js
+++ b/lib/radio-controller.js
@@ -41,7 +41,7 @@ exports.create = function (radio, messagingClient, logger) {
   function createEmitterForState(eventName) {
     return function (state) {
       return emitEventsForState(eventName, state);
-    }
+    };
   }
 
   function emitEventsForState(eventName, state) {
@@ -121,4 +121,4 @@ exports.create = function (radio, messagingClient, logger) {
   function eventTopicKey(topic) {
     return 'event.player.' + radio.id + '.' + topic;
   }
-}
+};

--- a/lib/radio-controller.js
+++ b/lib/radio-controller.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var action       = require('./action'),
     state        = require('./state'),
     stateEmitter = require('./state-emitter'),

--- a/lib/radio-discovery.js
+++ b/lib/radio-discovery.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils           = require('radiodan-client').utils,
     MessagingClient = require('radiodan-client').MessagingClient,
     topicKey        = 'command.discovery.player',

--- a/lib/radio-discovery.js
+++ b/lib/radio-discovery.js
@@ -13,7 +13,7 @@ exports.create = function(radios, messagingClient) {
   logger = utils.logger(__filename);
 
   listenForCommands(response, messagingClient);
-}
+};
 
 function extractDiscoveryFromRadio(radio) {
   var info = {
@@ -46,7 +46,7 @@ function respondToCommand(response, messagingClient) {
     }
 
     data.ack();
-  }
+  };
 }
 
 function listenForCommands(response, messagingClient) {

--- a/lib/radio-player.js
+++ b/lib/radio-player.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils           = require('radiodan-client').utils,
     MessagingClient = require('radiodan-client').MessagingClient,
     Player          = require('./player'),

--- a/lib/state-emitter.js
+++ b/lib/state-emitter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Invoker   = require('./invoker'),
     utils     = require('radiodan-client').utils,
     logger    = utils.logger(__filename),

--- a/lib/state-emitter.js
+++ b/lib/state-emitter.js
@@ -30,7 +30,7 @@ module.exports = function() {
     cache[methodName] = newData;
 
     return invoker.invoke(oldData, methodName, newData);
-  }
+  };
 
   return instance;
-}()
+}();

--- a/lib/state-emitters/player.js
+++ b/lib/state-emitters/player.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils  = require('radiodan-client').utils,
     logger = utils.logger('state-emitters-player');
 

--- a/lib/state-emitters/player.js
+++ b/lib/state-emitters/player.js
@@ -18,4 +18,4 @@ module.exports = function(oldData, newData) {
   });
 
   return utils.promise.resolve(newKeys);
-}
+};

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Invoker   = require('./invoker'),
     validator = require('./validators/state');
 

--- a/lib/states/database.js
+++ b/lib/states/database.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/states/database.js
+++ b/lib/states/database.js
@@ -3,7 +3,7 @@ var utils = require('radiodan-client').utils;
 module.exports = function(radio, options) {
   return radio.sendCommands([['stats']])
               .then(function(stats) {
-                var stats = radio.formatResponse(stats);
+                stats = radio.formatResponse(stats);
                 return utils.promise.resolve({
                   'totals': {
                     'artists' : stats.artists,

--- a/lib/states/player.js
+++ b/lib/states/player.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/states/playlist.js
+++ b/lib/states/playlist.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils,
     playlistInfo = function(radio, options) {
       return radio.sendCommands([['playlistinfo']])

--- a/lib/states/volume.js
+++ b/lib/states/volume.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {

--- a/lib/states/volume.js
+++ b/lib/states/volume.js
@@ -1,8 +1,9 @@
 var utils = require('radiodan-client').utils;
 
 module.exports = function(radio, options) {
-  var options = options || {},
-      state   = options.state || require('../state');
+  var state;
+  options = options || {};
+  state   = options.state || require('../state');
 
   return state.invoke(radio, 'player')
               .then(function (status) {

--- a/lib/system/audio.js
+++ b/lib/system/audio.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var sprintf         = require('sprintf').sprintf,
     MessagingClient = require('radiodan-client').MessagingClient,
     utils           = require('radiodan-client').utils,
@@ -22,13 +24,13 @@ var sprintf         = require('sprintf').sprintf,
 module.exports = {create: create};
 
 function create(id) {
-  var topicKey        = 'command.audio.'+id;
+  var topicKey        = 'command.audio.'+id,
       eventTopicKey   = 'event.audio.'+id+'.volume';
 
   return { listen: listen };
 
   function listen(msgClient, platform, exec, logger) {
-    var audioType, commands;
+    var audioType, commands, messagingClient;
 
     messagingClient = msgClient   || MessagingClient.create();
     platform        = platform    || process.platform;

--- a/lib/system/audio.js
+++ b/lib/system/audio.js
@@ -25,7 +25,7 @@ function create(id) {
   var topicKey        = 'command.audio.'+id;
       eventTopicKey   = 'event.audio.'+id+'.volume';
 
-  return { listen: listen }
+  return { listen: listen };
 
   function listen(msgClient, platform, exec, logger) {
     var audioType, commands;
@@ -52,10 +52,12 @@ function create(id) {
     });
 
     messagingClient.on(topicKey, function(data){
+      var action, replyToQueue, correlationId;
+
       try {
-        var action        = data.content.action,
-            replyToQueue  = data.properties.replyTo,
-            correlationId = data.content.correlationId;
+        action        = data.content.action;
+        replyToQueue  = data.properties.replyTo;
+        correlationId = data.content.correlationId;
       } catch(err) {
         logger.warn("Cannot respond", err);
       }
@@ -162,7 +164,7 @@ function create(id) {
         } else {
           return response;
         }
-      }
+      };
     }
 
     function emitVolume(vol) {
@@ -173,4 +175,4 @@ function create(id) {
       );
     }
   }
-};
+}

--- a/lib/utils/bound-volume.js
+++ b/lib/utils/bound-volume.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function (currentVol, diff) {
   var vol;
 

--- a/lib/validators/action.js
+++ b/lib/validators/action.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Invoker  = require('../invoker'),
     utils    = require('radiodan-client').utils,
     toggle   = require('./actions/toggle'),

--- a/lib/validators/actions/database/search.js
+++ b/lib/validators/actions/database/search.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils,
     validScopes = ["artist", "album", "title", "track", "name", "genre",
     "date", "composer", "performer", "comment", "disc", "filename", "any"];

--- a/lib/validators/actions/database/update.js
+++ b/lib/validators/actions/database/update.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(options) {

--- a/lib/validators/actions/player/play.js
+++ b/lib/validators/actions/player/play.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(options) {

--- a/lib/validators/actions/player/seek.js
+++ b/lib/validators/actions/player/seek.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(options) {

--- a/lib/validators/actions/player/volume.js
+++ b/lib/validators/actions/player/volume.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(options) {

--- a/lib/validators/actions/playlist/add.js
+++ b/lib/validators/actions/playlist/add.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(options) {

--- a/lib/validators/actions/playlist/add.js
+++ b/lib/validators/actions/playlist/add.js
@@ -3,7 +3,7 @@ var utils = require('radiodan-client').utils;
 module.exports = function(options) {
   var validOptions;
 
-  if(!options.playlist || options.playlist.length == 0) {
+  if(!options.playlist || options.playlist.length === 0) {
     return utils.promise.reject(new Error('Playlist is empty'));
   }
 

--- a/lib/validators/actions/playlist/move.js
+++ b/lib/validators/actions/playlist/move.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils,
     position = require('../position');
 

--- a/lib/validators/actions/position.js
+++ b/lib/validators/actions/position.js
@@ -32,7 +32,7 @@ function parseOptions(options) {
 }
 
 function parseRange(start, end) {
-  start = parseInt(start, 10),
+  start = parseInt(start, 10);
   end   = parseInt(end, 10);
 
   if(start < 0 || end < 0) {

--- a/lib/validators/actions/position.js
+++ b/lib/validators/actions/position.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(options) {

--- a/lib/validators/actions/toggle.js
+++ b/lib/validators/actions/toggle.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var utils = require('radiodan-client').utils;
 
 module.exports = function(options) {

--- a/lib/validators/state-emitter.js
+++ b/lib/validators/state-emitter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var deepEqual = require('deep-equal'),
     Invoker   = require('../invoker'),
     utils     = require('radiodan-client').utils,

--- a/lib/validators/state.js
+++ b/lib/validators/state.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Invoker = require('../invoker'),
     utils   = require('radiodan-client').utils;
 

--- a/lib/wait-for-socket.js
+++ b/lib/wait-for-socket.js
@@ -1,11 +1,12 @@
-var net    = require('net');
+var net    = require('net'),
     utils  = require('radiodan-client').utils,
     logger = utils.logger(__filename);
 
 function create(port, socket) {
   var deferred = utils.promise.defer(),
-      socket = socket || new net.Socket(),
       timeout = 1000;
+
+  socket = socket || new net.Socket();
 
   socket.setTimeout(2500);
 

--- a/lib/wait-for-socket.js
+++ b/lib/wait-for-socket.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var net    = require('net'),
     utils  = require('radiodan-client').utils,
     logger = utils.logger(__filename);

--- a/test/actions/database/test-search.js
+++ b/test/actions/database/test-search.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/database/search');
 
 describe('search action', function() {

--- a/test/actions/database/test-update.js
+++ b/test/actions/database/test-update.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/actions/database/update');
 
 describe('database action', function() {

--- a/test/actions/player/test-play.js
+++ b/test/actions/player/test-play.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/actions/player/play');
 
 describe('player.play action', function() {

--- a/test/actions/player/test-random.js
+++ b/test/actions/player/test-random.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/player/random');
 
 describe('player.random action', function() {

--- a/test/actions/player/test-repeat.js
+++ b/test/actions/player/test-repeat.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/player/repeat');
 
 describe('player.repeat action', function() {

--- a/test/actions/player/test-seek.js
+++ b/test/actions/player/test-seek.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/actions/player/seek');
 
 describe('player.seek action', function() {

--- a/test/actions/player/test-status.js
+++ b/test/actions/player/test-status.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/player/status');
 
 describe('player.status action', function() {

--- a/test/actions/player/test-volume.js
+++ b/test/actions/player/test-volume.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/player/volume');
 
 describe('volume action', function() {

--- a/test/actions/playlist/test-add.js
+++ b/test/actions/playlist/test-add.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/playlist/add');
 
 describe('playlist.add action', function() {

--- a/test/actions/playlist/test-load.js
+++ b/test/actions/playlist/test-load.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/playlist/load');
 
 describe('playlist.load action', function() {

--- a/test/actions/playlist/test-move.js
+++ b/test/actions/playlist/test-move.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/actions/playlist/move');
 
 describe('playlist.move action', function() {

--- a/test/actions/test-simple-command.js
+++ b/test/actions/test-simple-command.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'actions/simple-command');
 
 describe('simple-command action wrapper', function() {

--- a/test/actions/test-toggle-command.js
+++ b/test/actions/test-toggle-command.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/actions/toggle-command');
 
 describe('toggle command meta-action', function() {

--- a/test/bootstrap/test-add-system-defaults.js
+++ b/test/bootstrap/test-add-system-defaults.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/bootstrap/add-system-defaults');
 
 describe('bootstrap: add system defaults', function (){

--- a/test/bootstrap/test-config.js
+++ b/test/bootstrap/test-config.js
@@ -38,7 +38,7 @@ describe('bootstrap config', function (){
       'players': null
     };
 
-    assert.throw(function() { subject(config) }, 'No players found');
+    assert.throw(function() { subject(config); }, 'No players found');
   });
 
   it('populates using player data, even without defaults', function () {

--- a/test/bootstrap/test-config.js
+++ b/test/bootstrap/test-config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'bootstrap/config');
 
 describe('bootstrap config', function (){

--- a/test/bootstrap/test-create-paths.js
+++ b/test/bootstrap/test-create-paths.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var path = require('path'),
     subject = require(libDir + 'bootstrap/create-paths');
 

--- a/test/lib/test-action.js
+++ b/test/lib/test-action.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('action', function() {
   beforeEach(function() {
     this.subject = require(libDir + 'action');

--- a/test/lib/test-action.js
+++ b/test/lib/test-action.js
@@ -16,7 +16,7 @@ describe('action', function() {
   it('has actions in the form {topic}.{event}', function() {
     var allowedTopics = ['database', 'player', 'playlist'],
         actionFormat = new RegExp(
-          '^(' + allowedTopics.join('|') + '){1}\.\\w+$'
+          '^(' + allowedTopics.join('|') + '){1}\\.\\w+$'
         ),
         subject = this.subject,
         methodNames = Object.keys(subject.methods);

--- a/test/lib/test-child-process.js
+++ b/test/lib/test-child-process.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'child-process');
 
 describe('Child Process', function(){

--- a/test/lib/test-invoker.js
+++ b/test/lib/test-invoker.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Invoker = require(libDir + '/invoker');
 
 describe('action', function (){

--- a/test/lib/test-port-finder.js
+++ b/test/lib/test-port-finder.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var PortFinder = require(libDir + 'port-finder');
 
 describe('PortFinder', function (){

--- a/test/lib/test-port-finder.js
+++ b/test/lib/test-port-finder.js
@@ -6,7 +6,7 @@ describe('PortFinder', function (){
         portFinder.basePort = 49152;
         portFinder.nextPortPromise = function() {
           return utils.promise.resolve(portFinder.basePort++);
-        }
+        };
 
    this.portFinder = portFinder;
   });

--- a/test/lib/test-radio-discovery.js
+++ b/test/lib/test-radio-discovery.js
@@ -1,4 +1,6 @@
-var EventEmitter   = require('events').EventEmitter;
+'use strict';
+
+var EventEmitter   = require('events').EventEmitter,
     RadioDiscovery = require(libDir + '/radio-discovery');
 
 describe('radio discovery', function() {

--- a/test/lib/test-radio-discovery.js
+++ b/test/lib/test-radio-discovery.js
@@ -12,7 +12,7 @@ describe('radio discovery', function() {
 
   it('listens for discovery topics via the messaging client', function(done) {
     var messageClientMock = this.messageClientMock,
-        exchangeMock      = messageClientMock.createAndBindToExchange
+        exchangeMock      = messageClientMock.createAndBindToExchange;
 
     RadioDiscovery.create([this.radio], messageClientMock);
 

--- a/test/lib/test-state-emitter.js
+++ b/test/lib/test-state-emitter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('state-emitter', function (){
   beforeEach(function(){
     this.subject = require(libDir + 'state-emitter');

--- a/test/lib/test-state.js
+++ b/test/lib/test-state.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'state');
 
 describe('state', function() {

--- a/test/lib/test-wait-for-socket.js
+++ b/test/lib/test-wait-for-socket.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var waitForSocket = require(libDir + 'wait-for-socket');
 
 describe('waitForSocket', function(){

--- a/test/mpd/test-mpd-client.js
+++ b/test/mpd/test-mpd-client.js
@@ -27,7 +27,7 @@ describe('mpdClient', function (){
     assert.equal('play', command.name);
     assert.deepEqual(['1'], command.args);
 
-    var command = client.formatCommand(['play']);
+    command = client.formatCommand(['play']);
 
     assert.equal('play', command.name);
     assert.deepEqual([], command.args);
@@ -37,11 +37,11 @@ describe('mpdClient', function (){
     var client = subject.create(4321);
     var mpdMock = new EventEmitter();
     var commandSpy = sinon.spy();
-    mpdMock.sendCommands = function(commands,cb){ commandSpy(commands); cb(); }
+    mpdMock.sendCommands = function(commands,cb){ commandSpy(commands); cb(); };
 
     client.connect(mpdMock);
     // resolve promise sendCommand is reliant on
-    client.ready = function() { var d = utils.promise.defer(); d.resolve(); return d.promise;}
+    client.ready = function() { var d = utils.promise.defer(); d.resolve(); return d.promise; };
 
     var commandPromise = client.sendCommands([['add', '1.mp3']]);
 
@@ -62,7 +62,7 @@ describe('mpdClient', function (){
     var connectPromise = client.connect(mpdMock);
     mpdMock.emit('error');
 
-    mpdMock.sendCommands = function(commands,cb){ cb(); }
+    mpdMock.sendCommands = function(commands,cb){ cb(); };
     var commandPromise = client.sendCommands([['add', ['1.mp3']]]);
 
     assert.isRejected(connectPromise).then(function() {
@@ -77,7 +77,7 @@ describe('mpdClient', function (){
     mpdMock.emit('ready');
 
     var commandPromise = client.sendCommands([['add', ['1.mp3']]]);
-    mpdMock.sendCommands = function(commands,cb){ cb(); }
+    mpdMock.sendCommands = function(commands,cb){ cb(); };
 
     assert.isFulfilled(connectPromise).then(function() {
       assert.isFulfilled(commandPromise).notify(done);

--- a/test/mpd/test-mpd-client.js
+++ b/test/mpd/test-mpd-client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'player/mpd/client');
 
 describe('mpdClient', function (){

--- a/test/player/test-config.js
+++ b/test/player/test-config.js
@@ -44,7 +44,7 @@ describe('mpdConfig', function (){
     }).then(function(){
       return assert.isFulfilled(secondBuild).then(function(mpdContent) {
         assert.match(mpdContent, /^port (\s+) "6601"$/m);
-      })
+      });
     }).then(done,done);
   });
 

--- a/test/player/test-config.js
+++ b/test/player/test-config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/player/config');
 
 //TODO: split into MPD config, mopidy config, generic features

--- a/test/player/test-process.js
+++ b/test/player/test-process.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var playerProcess = require( libDir + '/player/player-process');
 
 describe('playerProcess', function() {

--- a/test/state-emitters/test-player.js
+++ b/test/state-emitters/test-player.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('state-emitter/player', function (){
   beforeEach(function(){
     this.subject = require(libDir + 'state-emitters/player');

--- a/test/states/test-database.js
+++ b/test/states/test-database.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'states/database');
 
 describe('database state', function() {

--- a/test/states/test-player.js
+++ b/test/states/test-player.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'states/player');
 
 describe('status action', function() {

--- a/test/states/test-playlist.js
+++ b/test/states/test-playlist.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'states/playlist');
 
 describe('playlist action', function() {

--- a/test/states/test-volume.js
+++ b/test/states/test-volume.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'states/volume');
 
 describe('volume state', function() {

--- a/test/system/test-audio.js
+++ b/test/system/test-audio.js
@@ -5,7 +5,7 @@ describe('system audio', function(){
     beforeEach(function(){
       var execPromise = utils.promise.defer();
 
-      this.msgMock = new EventEmitter;
+      this.msgMock = new EventEmitter();
       this.msgMock.createAndBindToExchange = sinon.spy();
       this.execPromise = execPromise;
     });

--- a/test/system/test-audio.js
+++ b/test/system/test-audio.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var audio = require(libDir + 'system/audio');
 
 describe('system audio', function(){

--- a/test/utils/bound-volume.js
+++ b/test/utils/bound-volume.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'utils/bound-volume');
 
 describe('boundVolume', function(){

--- a/test/validators/actions/database/test-search.js
+++ b/test/validators/actions/database/test-search.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/validators/actions/database/search');
 
 describe('validate database search', function() {

--- a/test/validators/actions/database/test-update.js
+++ b/test/validators/actions/database/test-update.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'validators/actions/database/update');
 
 describe('validate database action', function() {

--- a/test/validators/actions/player/test-play.js
+++ b/test/validators/actions/player/test-play.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'validators/actions/player/play');
 
 describe('validate player.play action', function() {

--- a/test/validators/actions/player/test-seek.js
+++ b/test/validators/actions/player/test-seek.js
@@ -47,7 +47,6 @@ describe('validate player.seek action', function() {
   it('rejects if position is not a number', function(done){
     var promise = subject({ position: {}, time: 31 });
     assert.isRejected(promise, Error).then(done, done);
-;
   });
 
   it('rejects if time is not a number', function(done){

--- a/test/validators/actions/player/test-seek.js
+++ b/test/validators/actions/player/test-seek.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'validators/actions/player/seek');
 
 describe('validate player.seek action', function() {

--- a/test/validators/actions/player/test-volume.js
+++ b/test/validators/actions/player/test-volume.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'validators/actions/player/volume');
 
 describe('volume validator', function() {

--- a/test/validators/actions/playlist/test-add.js
+++ b/test/validators/actions/playlist/test-add.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/validators/actions/playlist/add');
 
 describe('validate play action', function() {

--- a/test/validators/actions/playlist/test-move.js
+++ b/test/validators/actions/playlist/test-move.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + '/validators/actions/playlist/move');
 
 describe('validate move action', function() {

--- a/test/validators/actions/test-position.js
+++ b/test/validators/actions/test-position.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'validators/actions/position');
 
 describe('validate position action', function() {

--- a/test/validators/actions/test-toggle.js
+++ b/test/validators/actions/test-toggle.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'validators/actions/toggle');
 
 describe('validate toggle action', function() {

--- a/test/validators/test-action.js
+++ b/test/validators/test-action.js
@@ -16,7 +16,7 @@ describe('state', function() {
   it('has validators in the form {topic}.{event}', function() {
     var allowedTopics = ['database', 'player', 'playlist'],
         actionFormat = new RegExp(
-          '^(' + allowedTopics.join('|') + '){1}\.\\w+$'
+          '^(' + allowedTopics.join('|') + '){1}\\.\\w+$'
         ),
         methodNames = Object.keys(subject.methods);
 

--- a/test/validators/test-action.js
+++ b/test/validators/test-action.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var subject = require(libDir + 'validators/action');
 
 describe('state', function() {

--- a/test/validators/test-state-emitter.js
+++ b/test/validators/test-state-emitter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('validators state-emitter', function() {
   beforeEach(function() {
     this.subject = require(libDir + 'validators/state-emitter');

--- a/test/validators/test-state.js
+++ b/test/validators/test-state.js
@@ -1,3 +1,5 @@
+'use strict';
+
 describe('validators state', function() {
   beforeEach(function() {
     this.subject = require(libDir + 'validators/state');


### PR DESCRIPTION
Hi,

I'd like to add jshint code verification, and enable [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) in the radiodan.js codebase. These are both useful for finding potential errors in the code. I've added this to the project's Gruntfile and made code changes to fix any warnings generated (these were mostly syntactic). The default grunt task now runs jshint before running the unit tests and `grunt jshint` will run just the jshint step.

I hope this is OK!

Chris

